### PR TITLE
Fixed overwritten notes cateogory on css clicking

### DIFF
--- a/frontend/src/CssNotes/CssNote.jsx
+++ b/frontend/src/CssNotes/CssNote.jsx
@@ -12,7 +12,6 @@ export default function CssNote() {
     <NoteBar/>
       <Cssnav/>
       <Csshome/>
-      <NoteBar/>
     </div>
     </>
   )


### PR DESCRIPTION
on clicking css in tech notes all notes categories was overwritting 