### PR TITLE
Enable liking posts only for logged-in users

### DIFF
--- a/frontend/src/component/PostButtons.jsx
+++ b/frontend/src/component/PostButtons.jsx
@@ -1,65 +1,79 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from './Post.module.css';
 import Heart from 'react-animated-heart';
+
 export default function PostButtons() {
   const [click, setClick] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
-  const [isCommentsPost,setIsCommentsPost]=useState(false);
+  const [isCommentsPost, setIsCommentsPost] = useState(false);
   const [newComment, setNewComment] = useState("");
-  const [comments,setComments]=useState([])
+  const [comments, setComments] = useState([]);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  
+  useEffect(() => {
+    if (localStorage.getItem("username")!== null){
+      setIsLoggedIn(true);
+    }
+    else{
+      setIsLoggedIn(false);
+    }
+  }, []);
+
+  
+
   const handleLikeToggle = () => {
-    setClick(!click);
-    setLikeCount(likeCount + (click ? -1 : 1));
+    // if (localStorage.getItem("username") !== "") {
+    //   setIsLoggedIn(true);
+    // }
+    if (isLoggedIn) {
+      setClick(!click);
+      setLikeCount(likeCount + (click ? -1 : 1));
+    } else {
+      alert("Please log in to like the post.");
+    }
   };
-  function handleCommentClick(e){
+
+  function handleCommentClick(e) {
     e.stopPropagation();
     setIsCommentsPost(true);
   }
-  function handleCommentClose(){
+
+  function handleCommentClose() {
     setIsCommentsPost(false);
   }
-  function handleComments(){
-    // e.prevent.default();
-    setComments([...comments,newComment])
+
+  function handleComments() {
+    setComments([...comments, newComment]);
   }
+
   return (
     <div className={styles.reactions}>
       <div className={styles.likeContainer}>
-        <Heart  onClick={handleLikeToggle} />
+        <Heart onClick={handleLikeToggle} filled={click}  />
         <span className={styles.likeCount}>{likeCount}</span>
       </div>
       <i onClick={handleCommentClick} className="fa-regular fa-comments"></i>
-          <i className="fa-regular fa-share-from-square"></i>
-          <i className="fa-regular fa-bookmark"></i>
+      <i className="fa-regular fa-share-from-square"></i>
+      <i className="fa-regular fa-bookmark"></i>
       {isCommentsPost && (
         <div className={styles.popup}>
           <div className={styles.popHeader}>
             <h3 className={styles.poptitle}>Comments</h3>
-            <button onClick={handleCommentClose}>
-              close
-            </button>
+            <button onClick={handleCommentClose}>close</button>
           </div>
-          {comments.map((value,index)=><li key={index}>{value}</li>)}
-          
+          {comments.map((value, index) => (
+            <li key={index}>{value}</li>
+          ))}
           <hr />
           <input
-          placeholder="Add a comment"
-          value={newComment}
-          onChange={(e) => setNewComment(e.target.value)}
+            placeholder="Add a comment"
+            value={newComment}
+            onChange={(e) => setNewComment(e.target.value)}
           ></input>
-          <button onClick={handleComments} >Post</button>
-          {/* <input
-          placeholder="Add a comment"
-          value={newComment}
-          onChange={(e) => setNewComment(e.target.value)}
-          ></input>
-          <button onClick={handleComments}>Post</button> */}
-          
+          <button onClick={handleComments}>Post</button>
           <hr />
-          </div>
-          )}
-      
-      
-     </div>
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION

<img width="1440" alt="Screenshot 2024-03-12 at 11 35 16 AM" src="https://github.com/GauravPandey123webdeveloper/TechiSpot/assets/153702756/4d443ad1-e7ee-411a-9b82-a82107064b95">

Prevent unauthorized likes by requiring users to log in before liking posts

Updated the handleLikeToggle function to prevent unauthorized likes on posts. Now, only logged-in users can like posts. When an unauthenticated user attempts to like a post, they are prompted to log in before proceeding. This ensures that only authenticated users can interact with the like functionality, maintaining data integrity and preventing unauthorized actions.


<img width="1440" alt="Screenshot 2024-03-12 at 11 35 16 AM" src="https://github.com/GauravPandey123webdeveloper/TechiSpot/assets/153702756/6740518e-4328-4c17-88a6-a8d7ca8e7456">

After login you can like the post . 

