### PR TITLE
Add a modal for creating new communities 

### DIFF
--- a/frontend/src/component/SideBar.jsx
+++ b/frontend/src/component/SideBar.jsx
@@ -1,13 +1,67 @@
-import React from 'react'
-import styles from './SideBar.module.css'
-import  Communities from '../home/community/Communities'
+import React, { useState } from 'react';
+import styles from './SideBar.module.css';
+import Communities from '../home/community/Communities';
+import { Modal, Button, Input } from '@mui/material';
+
 export default function SideBar() {
+  const [openModal, setOpenModal] = useState(false);
+  const [newCommunityName, setNewCommunityName] = useState('');
+
+  const handleOpenModal = () => {
+    setOpenModal(true);
+  };
+
+  const handleCloseModal = () => {
+    setOpenModal(false);
+  };
+
+  const handleSaveCommunity = () => {
+    // Implement logic to save the new community
+    console.log('Saving community:', newCommunityName);
+    setNewCommunityName(''); // Clear the input field
+    setOpenModal(false); // Close the modal
+  };
+
   return (
     <div className={styles.community}>
-      <div className={styles.box}><h1 className={styles.commhead}>Community</h1> <button  className={`${styles.iconButton}`}><i className={`fa-regular fa-plus`}></i></button></div>
-       <div className={styles.chats}>
-        <Communities/>
+      <div className={styles.box}>
+        <h1 className={styles.commhead}>Community</h1>
+        <button className={`${styles.iconButton}`} onClick={handleOpenModal}>
+          <i className={`fa-regular fa-plus`}></i>
+        </button>
       </div>
+      <div className={styles.chats}>
+        <Communities />
+      </div>
+      <Modal open={openModal} onClose={handleCloseModal}>
+        <div className={styles.modalContent}>
+          <h2>Add Community</h2>
+          <label for="communityNameInput"> 
+          <input
+            type="text"
+            id="communityNameInput"
+            placeholder="Community Name"
+            value={newCommunityName}
+            onChange={(e) => setNewCommunityName(e.target.value)}
+          />
+          </label>
+          <br /> <br />
+          <div className={styles.saveNDcancel}>
+            <Button variant="contained" onClick={handleCloseModal}>
+              Cancel
+            </Button>
+
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSaveCommunity}
+              style={{ marginRight: '10px' }}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/component/SideBar.module.css
+++ b/frontend/src/component/SideBar.module.css
@@ -1,4 +1,4 @@
-.community{
+.community {
     width: 24vw;
     box-shadow: 0px 0px 2px;
     height: 90vh;
@@ -29,46 +29,85 @@
     height: 9.5vh;
 
 }
- 
+
 h1 {
     display: inline;
-    font-size: 33px; 
+    font-size: 33px;
 }
-.iconButton{
-  margin-left: 100px;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  font-size: 26px;
-  color: #f2eeee;
+
+.iconButton {
+    margin-left: 100px;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    font-size: 26px;
+    color: #f2eeee;
 }
-.iconButton:hover{
-   font-size: 28px;
+
+.iconButton:hover {
+    font-size: 28px;
 }
+
 .chats {
     margin-top: 6vh;
     margin-left: -2.6vh;
     width: 23vw;
-    top: 50; 
-    position: relative; 
+    top: 50;
+    position: relative;
 }
+
 @media screen and (max-width:600px) {
     .community {
         display: none;
     }
 }
-.community::-webkit-scrollbar{
+
+.community::-webkit-scrollbar {
     display: none;
-  }
-  .commhead{
+}
+
+.commhead {
     font-size: 3vw;
     margin-left: 1vw;
     margin-right: -2vw;
     margin-bottom: 1vw;
     font-family: emoji;
-    background: linear-gradient(to right,#f66492 ,rgb(228, 227, 227),#5bf7f1   );
+    background: linear-gradient(to right, #f66492, rgb(228, 227, 227), #5bf7f1);
     -webkit-text-fill-color: transparent;
     -webkit-background-clip: text;
-  }
-  
+}
+
+
+
+
+/* Modal styles */
+
+.modalContent {
+    background-color: black;
+    padding: 50px;
+    border-radius: 20px;
+    width: 30vw;
+    margin: 0 auto;
+    margin-top: 100px;
+    text-align: center;
+}
+
+.modalContent h2 {
+    color: white;
+    font-size: 25px;
+}
+
+.modalContent button {
+    margin-right: 10px;
+}
+
+.input {
+    margin-bottom: 20px;
+    width: 100%;
+    padding: 10px;
+    border-radius: 5px;
+    border: 5px solid transparent; 
+    background-color: transparent;
+}
+

--- a/frontend/src/home/post/Post.module.css
+++ b/frontend/src/home/post/Post.module.css
@@ -1,6 +1,6 @@
 .post {
   width: 51vw;
-  box-shadow: 0px 0px 10px;
+  box-shadow: 0px 0px 2px;
   height: 100vh;
   padding: 1vh;
   margin-left: 24vw;

--- a/frontend/src/home/team/TeamCard.jsx
+++ b/frontend/src/home/team/TeamCard.jsx
@@ -10,7 +10,7 @@ export default function TeamCard() {
       <img src={member.pro} className={styles.img} alt="Profile_Pic" />
       <div className={styles.data}>
         <h4>{member.name}</h4>
-        <p>About: {member.about}</p>
+        <p>{member.about}</p>
         <div className={styles.socialLinks}>
           <a href={member.linkedin} target="_blank" rel="noopener noreferrer">
             <img src={linkedIn} alt="linkedIn" className={styles.linkedin}/>

--- a/frontend/src/projects/Mentors/MentorCard.jsx
+++ b/frontend/src/projects/Mentors/MentorCard.jsx
@@ -7,7 +7,7 @@ export default function MentorCard() {
       <img src={member.pro} className={styles.img} alt="Profile_Pic" />
       <div className={styles.data}>
         <h4>{member.name}</h4>
-        <p>About: {member.about}</p>
+        <p>{member.about}</p>
         <div className={styles.socialLinks}>
         <button className={styles.btn}>Book Now</button>
         </div>


### PR DESCRIPTION
In the component folder, a sidebar has been implemented to manage community-related functionality. Within this sidebar, a modal has been integrated using Material UI to facilitate the creation of new communities.  
 

<img width="1440" alt="Screenshot 2024-03-12 at 11 44 18 PM" src="https://github.com/GauravPandey123webdeveloper/TechiSpot/assets/150504436/025b9da9-609e-45d7-a1c4-5020c9ca4545">


Along with that, several enhancements have been made to improve the user interface. Specifically, I removed certain box shadows to provide a cleaner appearance and removed the unnecessary 'About' prefix from professions, which was occupying unnecessary space. These changes aim to optimize the user experience and streamline the interface for better usability.